### PR TITLE
use a published link for DCO description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The following are a set of guidelines to help you contribute.
 
 > :warning: _All code contributed must be made under an Apache 2 license._
 >
-> :warning: _All contributions must be accompanied by a [Developer Certification of Origin (DCO) signoff](https://github.com/openmainframeproject/tsc/blob/master/process/contribution_guidelines.md#developer-certificate-of-origin)._
+> :warning: _All contributions must be accompanied by a [Developer Certification of Origin (DCO) signoff](https://tac.openmainframeproject.org/process/contribution_guidelines.html#contribution-sign-off)._
 
 ## Ways to Contribute
 


### PR DESCRIPTION
### :bulb: Issue Reference

No open issue

### :computer: What does this address?

The existing link brings you to github source for the documentation instead of the published version. At least in my browser, this makes the automated page scrolling to the anchor point fail to work.

### :pager: Implementation Details

Found the published link that does allow for the anchor to properly bring you directly to the needed information

### :clipboard: Is there a test case?

No test.
